### PR TITLE
Check for status code 2 for invalid password

### DIFF
--- a/pdfbrute.sh
+++ b/pdfbrute.sh
@@ -3,7 +3,8 @@
 wordname=$1
 while read -r line; do
 	qpdf --decrypt --password="$line" $2 $2.pdf  2> /dev/null
-	if [ $? -eq 0 ]; then
+	# Invalid password returns status code 2
+	if [ $? -ne 2 ]; then
 		echo "Password is $line"
 	fi
 	rm -rf $2.pdf


### PR DESCRIPTION
Removing the password might create a not 100% compliant PDF, which qpdf returns with status code 3.
Checking for status code 2 is better suited, as this is returned as status code in case of an invalid password.